### PR TITLE
Support react 17 as peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-hls-player",
-  "version": "2.0.0",
+  "version": "3.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-hls-player",
-      "version": "2.0.0",
+      "version": "3.0.7",
       "license": "MIT",
       "dependencies": {
         "hls.js": "^0.14.17"
@@ -36,8 +36,8 @@
         "webpack-merge": "^5.0.9"
       },
       "peerDependencies": {
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1"
+        "react": ">=16.13.1",
+        "react-dom": "^16.13.1 || ^17.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "hls.js": "^0.14.17"
   },
   "peerDependencies": {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": ">=16.13.1",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@types/hls.js": "^0.13.3",


### PR DESCRIPTION
As per https://github.com/devcshort/react-hls/issues/34 peerDependency errors are emitted when using this module with react 17. This change should suppress these errors, we have tested it using a sample video.

Users are welcome to use a [deployed artifact of @panelist/react-hls-player](https://www.npmjs.com/package/@panelist/react-hls-player) until this is merged / #34 is resolved.